### PR TITLE
Added adaptor for SwiftModules.com

### DIFF
--- a/Sources/server/PackageController.swift
+++ b/Sources/server/PackageController.swift
@@ -14,8 +14,8 @@ class PackageController {
     let thirdPartyAdapters: [ThirdPartyIndexAdapter]
     required init() {
         self.thirdPartyAdapters = [
-            SwiftModulesAdapter(),
             SwiftPackageCatalogAdapter(),
+            SwiftModulesAdapter(),
             CocoaPodsAdapter()
         ]
     }

--- a/Sources/server/PackageController.swift
+++ b/Sources/server/PackageController.swift
@@ -14,6 +14,7 @@ class PackageController {
     let thirdPartyAdapters: [ThirdPartyIndexAdapter]
     required init() {
         self.thirdPartyAdapters = [
+            SwiftModulesAdapter(),
             SwiftPackageCatalogAdapter(),
             CocoaPodsAdapter()
         ]

--- a/Sources/server/SwiftModulesAdapter.swift
+++ b/Sources/server/SwiftModulesAdapter.swift
@@ -1,0 +1,65 @@
+//
+//  SwiftModulesAdapter.swift
+//  swift-index
+//
+//  Created by Cory Alder on 5/12/16.
+//
+//
+
+import shared
+import HTTPSClient
+import Vapor
+import JSON
+
+struct SwiftModulesAdapter: ThirdPartyIndexAdapter {
+    
+    var name: String = "Swift Modules"
+    
+    func search(_ query: String) throws -> [PackageInfo] {
+        
+        let raw = try self.fetch(query)
+        let results = try self.convert(raw)
+        return results
+    }
+    
+    private func fetch(_ query: String) throws -> JSON {
+        //https://swiftpkgs.ng.bluemix.net/api/search/jay?page=1&items=13
+        
+        let uri = URI(scheme: "https", host:"swiftmodules.com", port:443)
+        let path = "/es/_search?q=\(query)"
+        let client = try Client(uri: uri)
+        var response : Response = try client.get(path)
+        guard response.status == .ok else {
+            throw Abort.custom(status: .internalServerError, message: "Failed to contact CocoaPods server")
+        }
+        let data = try response.body.becomeBuffer()
+        let json = try JSONParser().parse(data: data)
+        return json
+    }
+    
+    private func convert(_ raw: JSON) throws -> [PackageInfo] {
+        
+        guard let dict = raw.dictionary else {
+            throw Abort.custom(status: .internalServerError, message: "\(self.name) server returned an invalid result")
+        }
+        
+        guard let array = dict["hits"]?.dictionary?["hits"]?.array else {
+            throw Abort.custom(status: .internalServerError, message: "\(self.name) server returned an invalid result array")
+        }
+        
+        let results: [PackageInfo] = array
+            .flatMap { $0.dictionary }
+            .flatMap { rawObj in
+                guard let obj = rawObj["_source"]?.dictionary else { return nil }
+                guard let id = obj["packageName"]?.string else { return nil }
+                guard let owner = obj["owner"]?.string else { return nil }
+                guard let repo = obj["repo"]?.string else { return nil }
+                guard let description = obj["summary"]?.string else { return nil }
+                guard let version = obj["versions"]?.string else { return nil }
+                let origin = "https://github.com/\(owner)/\(repo).git"
+                return PackageInfo(name: id, origin: origin, description: description, version: version, sourceIndex: name)
+        }
+        return results
+    }
+}
+

--- a/Sources/server/SwiftModulesAdapter.swift
+++ b/Sources/server/SwiftModulesAdapter.swift
@@ -23,10 +23,10 @@ struct SwiftModulesAdapter: ThirdPartyIndexAdapter {
     }
     
     private func fetch(_ query: String) throws -> JSON {
-        //https://swiftpkgs.ng.bluemix.net/api/search/jay?page=1&items=13
+        //Sample search url: https://swiftmodules.com/es/_search?q=query&size=5
         
         let uri = URI(scheme: "https", host:"swiftmodules.com", port:443)
-        let path = "/es/_search?q=\(query)"
+        let path = "/es/_search?q=\(query)&size=5"
         let client = try Client(uri: uri)
         var response : Response = try client.get(path)
         guard response.status == .ok else {

--- a/Sources/server/SwiftModulesAdapter.swift
+++ b/Sources/server/SwiftModulesAdapter.swift
@@ -30,7 +30,7 @@ struct SwiftModulesAdapter: ThirdPartyIndexAdapter {
         let client = try Client(uri: uri)
         var response : Response = try client.get(path)
         guard response.status == .ok else {
-            throw Abort.custom(status: .internalServerError, message: "Failed to contact CocoaPods server")
+            throw Abort.custom(status: .internalServerError, message: "Failed to contact \(name) server")
         }
         let data = try response.body.becomeBuffer()
         let json = try JSONParser().parse(data: data)


### PR DESCRIPTION
Tested locally, compiles without errors and returns results. An example query that returns results from both IBM and SM `/v1/packages?q=coryalder`.
